### PR TITLE
chore(ci): add release workflow triggered on tag push(#3)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What’s changed
- Added `permissions: contents: write` to allow release creation

### Related Issue
Closes #3