### PR TITLE
Align dark selection style with Notion

### DIFF
--- a/notion-style-dark.css
+++ b/notion-style-dark.css
@@ -85,6 +85,11 @@ body {
   box-sizing: border-box;
 }
 
+/* Selection */
+::selection {
+  background-color: #24364e;
+}
+
 img {
   border-radius: 10px;
 }


### PR DESCRIPTION
This PR adjusts the selection background color in dark mode to better match Notion’s style.

Change:
- Add a dark theme selection rule:


File touched:
- notion-style-dark.css

Fixes #9