### PR TITLE
Fix code block font and multi-selection contrast issues

### DIFF
--- a/notion-style-dark-enhanced.css
+++ b/notion-style-dark-enhanced.css
@@ -1033,6 +1033,22 @@ code {
   color: var(--code-selection-color) !important;
 }
 
+.cm-s-inner .CodeMirror-line::selection,
+.cm-s-inner .CodeMirror-line > span::selection,
+.cm-s-inner .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line::selection,
+.cm-s-typora-default .CodeMirror-line > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-inner .CodeMirror-line::-moz-selection,
+.cm-s-inner .CodeMirror-line > span::-moz-selection,
+.cm-s-inner .CodeMirror-line > span > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span > span::-moz-selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 mark {
   background-color: var(--highlight-bg);
   color: rgba(55, 53, 47, 1);

--- a/notion-style-dark-enhanced.css
+++ b/notion-style-dark-enhanced.css
@@ -1038,7 +1038,11 @@ code {
 .cm-s-inner .CodeMirror-line > span > span::selection,
 .cm-s-typora-default .CodeMirror-line::selection,
 .cm-s-typora-default .CodeMirror-line > span::selection,
-.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 .cm-s-inner .CodeMirror-line::-moz-selection,
 .cm-s-inner .CodeMirror-line > span::-moz-selection,
 .cm-s-inner .CodeMirror-line > span > span::-moz-selection,

--- a/notion-style-dark-enhanced.css
+++ b/notion-style-dark-enhanced.css
@@ -697,8 +697,7 @@ li p {
 }
 
 pre {
-  --monospace: "Cascadia Code Variable", SFMono-Regular, Menlo, Consolas,
-    "PT Mono", "Liberation Mono";
+  --monospace: var(--monospace-font);
 }
 
 /* Code fences */

--- a/notion-style-dark.css
+++ b/notion-style-dark.css
@@ -374,8 +374,7 @@ p {
    * ---------------------
 */
 pre {
-  --monospace: "Cascadia Code Variable", SFMono-Regular, Menlo, Consolas,
-    "PT Mono", "Liberation Mono";
+  --monospace: var(--monospace-font);
 }
 
 .md-fences {

--- a/notion-style-dark.css
+++ b/notion-style-dark.css
@@ -58,6 +58,8 @@
   /* Code Block */
   --code-block-bg-color: #202020;
   --code-tooltip-border-color: #373737;
+  --code-selection-bg: #24364e;
+  --code-selection-color: #d4d4d4;
 
   /* TODO */
   --todo-bg-color: #2483e2;
@@ -88,7 +90,35 @@ body {
 
 /* Selection */
 ::selection {
-  background-color: #24364e;
+  background-color: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
+.cm-s-inner .CodeMirror-selected,
+.cm-s-typora-default .CodeMirror-selected {
+  background: rgba(0, 0, 0, 0) !important;
+}
+
+.cm-s-inner .CodeMirror-selectedtext,
+.cm-s-typora-default .CodeMirror-selectedtext {
+  background: var(--code-selection-bg) !important;
+  color: var(--code-selection-color) !important;
+}
+
+.cm-s-inner .CodeMirror-line::selection,
+.cm-s-inner .CodeMirror-line > span::selection,
+.cm-s-inner .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line::selection,
+.cm-s-typora-default .CodeMirror-line > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-inner .CodeMirror-line::-moz-selection,
+.cm-s-inner .CodeMirror-line > span::-moz-selection,
+.cm-s-inner .CodeMirror-line > span > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span > span::-moz-selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
 }
 
 img {

--- a/notion-style-dark.css
+++ b/notion-style-dark.css
@@ -110,7 +110,11 @@ body {
 .cm-s-inner .CodeMirror-line > span > span::selection,
 .cm-s-typora-default .CodeMirror-line::selection,
 .cm-s-typora-default .CodeMirror-line > span::selection,
-.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 .cm-s-inner .CodeMirror-line::-moz-selection,
 .cm-s-inner .CodeMirror-line > span::-moz-selection,
 .cm-s-inner .CodeMirror-line > span > span::-moz-selection,

--- a/notion-style-light-enhanced.css
+++ b/notion-style-light-enhanced.css
@@ -997,6 +997,22 @@ code {
   color: var(--code-selection-color) !important;
 }
 
+.cm-s-inner .CodeMirror-line::selection,
+.cm-s-inner .CodeMirror-line > span::selection,
+.cm-s-inner .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line::selection,
+.cm-s-typora-default .CodeMirror-line > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-inner .CodeMirror-line::-moz-selection,
+.cm-s-inner .CodeMirror-line > span::-moz-selection,
+.cm-s-inner .CodeMirror-line > span > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span > span::-moz-selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 mark {
   background-color: var(--highlight-bg);
   color: rgba(55, 53, 47, 1);

--- a/notion-style-light-enhanced.css
+++ b/notion-style-light-enhanced.css
@@ -1002,7 +1002,11 @@ code {
 .cm-s-inner .CodeMirror-line > span > span::selection,
 .cm-s-typora-default .CodeMirror-line::selection,
 .cm-s-typora-default .CodeMirror-line > span::selection,
-.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 .cm-s-inner .CodeMirror-line::-moz-selection,
 .cm-s-inner .CodeMirror-line > span::-moz-selection,
 .cm-s-inner .CodeMirror-line > span > span::-moz-selection,

--- a/notion-style-light-enhanced.css
+++ b/notion-style-light-enhanced.css
@@ -662,8 +662,7 @@ li p {
 }
 
 pre {
-  --monospace: "Cascadia Code Variable", SFMono-Regular, Menlo, Consolas,
-    "PT Mono", "Liberation Mono";
+  --monospace: var(--monospace-font);
 }
 
 /* Code fences */

--- a/notion-style-light.css
+++ b/notion-style-light.css
@@ -112,7 +112,11 @@ img {
 .cm-s-inner .CodeMirror-line > span > span::selection,
 .cm-s-typora-default .CodeMirror-line::selection,
 .cm-s-typora-default .CodeMirror-line > span::selection,
-.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
 .cm-s-inner .CodeMirror-line::-moz-selection,
 .cm-s-inner .CodeMirror-line > span::-moz-selection,
 .cm-s-inner .CodeMirror-line > span > span::-moz-selection,

--- a/notion-style-light.css
+++ b/notion-style-light.css
@@ -317,8 +317,7 @@ p {
    * ---------------------
 */
 pre {
-  --monospace: "Cascadia Code Variable", SFMono-Regular, Menlo, Consolas,
-    "PT Mono", "Liberation Mono";
+  --monospace: var(--monospace-font);
 }
 
 .md-fences {

--- a/notion-style-light.css
+++ b/notion-style-light.css
@@ -55,6 +55,8 @@
   /* Code Block */
   --code-block-bg-color: #f7f6f3;
   --code-tooltip-border-color: #dfdfde;
+  --code-selection-bg: rgba(35, 131, 226, 0.25);
+  --code-selection-color: var(--text-color);
 
   /* TODO */
   --todo-bg-color: #2483e2;
@@ -86,6 +88,39 @@ body {
 
 img {
   border-radius: 10px;
+}
+
+/* Selection */
+::selection {
+  background-color: var(--code-selection-bg);
+  color: var(--code-selection-color);
+}
+
+.cm-s-inner .CodeMirror-selected,
+.cm-s-typora-default .CodeMirror-selected {
+  background: rgba(0, 0, 0, 0) !important;
+}
+
+.cm-s-inner .CodeMirror-selectedtext,
+.cm-s-typora-default .CodeMirror-selectedtext {
+  background: var(--code-selection-bg) !important;
+  color: var(--code-selection-color) !important;
+}
+
+.cm-s-inner .CodeMirror-line::selection,
+.cm-s-inner .CodeMirror-line > span::selection,
+.cm-s-inner .CodeMirror-line > span > span::selection,
+.cm-s-typora-default .CodeMirror-line::selection,
+.cm-s-typora-default .CodeMirror-line > span::selection,
+.cm-s-typora-default .CodeMirror-line > span > span::selection,
+.cm-s-inner .CodeMirror-line::-moz-selection,
+.cm-s-inner .CodeMirror-line > span::-moz-selection,
+.cm-s-inner .CodeMirror-line > span > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span::-moz-selection,
+.cm-s-typora-default .CodeMirror-line > span > span::-moz-selection {
+  background: var(--code-selection-bg);
+  color: var(--code-selection-color);
 }
 
 /*


### PR DESCRIPTION
Fixes #18

**Changes**

- **Respect `--monospace-font` in code blocks**: The `pre` rule hardcoded a fixed font stack for the internal `--monospace` custom property, silently overriding whatever font users configured via `--monospace-font`. Now it references `var(--monospace-font)` instead, across all 4 theme variants.

- **Fix unreadable multi-cursor selection text in code blocks**: CodeMirror's built-in stylesheet defines `.CodeMirror-line::selection` (and nested `span`/`-moz-` variants) with higher specificity than a plain `::selection` rule, so multi-cursor selections fell back to CodeMirror's default near-white background, making text unreadable. Added overrides scoped to `.cm-s-inner` / `.cm-s-typora-default`, using theme-driven `--code-selection-bg` / `--code-selection-color` variables (added to the base dark/light themes; already present in the enhanced variants).
